### PR TITLE
chore: api version update

### DIFF
--- a/deploy/aad/splunk-aad-logs-deploy-resources.json
+++ b/deploy/aad/splunk-aad-logs-deploy-resources.json
@@ -380,7 +380,7 @@
             },
             {
               "type": "Microsoft.Storage/storageAccounts/providers/diagnosticSettings",
-              "apiVersion": "2017-05-01-preview",
+              "apiVersion": "2021-05-01-preview",
               "tags": "[parameters('allResourceTags')]",
               "name": "[concat(variables('backupStorageAccountName'), '/Microsoft.Insights/', 'splunk-storage-account-diagnostic-settings')]",
               "dependsOn": [
@@ -469,7 +469,7 @@
             {
               "type": "Microsoft.Storage/storageAccounts/providers/diagnosticSettings",
               "tags": "[parameters('allResourceTags')]",
-              "apiVersion": "2017-05-01-preview",
+              "apiVersion": "2021-05-01-preview",
               "name": "[concat(variables('jobsStorageAccountName'), '/Microsoft.Insights/', 'splunk-storage-account-diagnostic-settings')]",
               "dependsOn": [
                 "[resourceId('Microsoft.Storage/storageAccounts', variables('jobsStorageAccountName'))]",
@@ -557,7 +557,7 @@
             {
               "type": "Microsoft.EventHub/namespaces/providers/diagnosticSettings",
               "tags": "[parameters('allResourceTags')]",
-              "apiVersion": "2017-05-01-preview",
+              "apiVersion": "2021-05-01-preview",
               "name": "[concat(variables('eventHubNamespaceName'), '/Microsoft.Insights/', 'splunk-eventhub-namespace-diagnostic-settings')]",
               "dependsOn": [
                 "[resourceId('Microsoft.EventHub/namespaces', variables('eventHubNamespaceName'))]",
@@ -590,7 +590,7 @@
             {
               "type": "Microsoft.Web/serverfarms/providers/diagnosticSettings",
               "tags": "[parameters('allResourceTags')]",
-              "apiVersion": "2017-05-01-preview",
+              "apiVersion": "2021-05-01-preview",
               "name": "[concat(variables('hostingPlanName'), '/Microsoft.Insights/', 'splunk-hosting-plan-diagnostic-settings')]",
               "dependsOn": [
                 "[resourceId('Microsoft.Web/serverfarms', variables('hostingPlanName'))]",
@@ -727,7 +727,7 @@
             {
               "type": "Microsoft.Web/sites/providers/diagnosticSettings",
               "tags": "[parameters('allResourceTags')]",
-              "apiVersion": "2017-05-01-preview",
+              "apiVersion": "2021-05-01-preview",
               "name": "[concat(variables('functionName'), '/Microsoft.Insights/', 'splunk-azure-function-diagnostic-settings')]",
               "dependsOn": [
                 "[resourceId('Microsoft.Web/sites', variables('functionName'))]",

--- a/deploy/activity/splunk-activity-logs-deploy-resources.json
+++ b/deploy/activity/splunk-activity-logs-deploy-resources.json
@@ -378,7 +378,7 @@
             {
               "type": "Microsoft.Storage/storageAccounts/providers/diagnosticSettings",
               "tags": "[parameters('allResourceTags')]",
-              "apiVersion": "2017-05-01-preview",
+              "apiVersion": "2021-05-01-preview",
               "name": "[concat(variables('backupStorageAccountName'), '/Microsoft.Insights/', 'splunk-storage-account-diagnostic-settings')]",
               "dependsOn": [
                 "[resourceId('Microsoft.Storage/storageAccounts', variables('backupStorageAccountName'))]",
@@ -464,7 +464,7 @@
             {
               "type": "Microsoft.Storage/storageAccounts/providers/diagnosticSettings",
               "tags": "[parameters('allResourceTags')]",
-              "apiVersion": "2017-05-01-preview",
+              "apiVersion": "2021-05-01-preview",
               "name": "[concat(variables('jobsStorageAccountName'), '/Microsoft.Insights/', 'splunk-storage-account-diagnostic-settings')]",
               "dependsOn": [
                 "[resourceId('Microsoft.Storage/storageAccounts', variables('jobsStorageAccountName'))]",
@@ -552,7 +552,7 @@
             {
               "type": "Microsoft.EventHub/namespaces/providers/diagnosticSettings",
               "tags": "[parameters('allResourceTags')]",
-              "apiVersion": "2017-05-01-preview",
+              "apiVersion": "2021-05-01-preview",
               "name": "[concat(variables('eventHubNamespaceName'), '/Microsoft.Insights/', 'splunk-eventhub-namespace-diagnostic-settings')]",
               "dependsOn": [
                 "[resourceId('Microsoft.EventHub/namespaces', variables('eventHubNamespaceName'))]",
@@ -585,7 +585,7 @@
             {
               "type": "Microsoft.Web/serverfarms/providers/diagnosticSettings",
               "tags": "[parameters('allResourceTags')]",
-              "apiVersion": "2017-05-01-preview",
+              "apiVersion": "2021-05-01-preview",
               "name": "[concat(variables('hostingPlanName'), '/Microsoft.Insights/', 'splunk-hosting-plan-diagnostic-settings')]",
               "dependsOn": [
                 "[resourceId('Microsoft.Web/serverfarms', variables('hostingPlanName'))]",
@@ -721,7 +721,7 @@
             {
               "type": "Microsoft.Web/sites/providers/diagnosticSettings",
               "tags": "[parameters('allResourceTags')]",
-              "apiVersion": "2017-05-01-preview",
+              "apiVersion": "2021-05-01-preview",
               "name": "[concat(variables('functionName'), '/Microsoft.Insights/', 'splunk-azure-function-diagnostic-settings')]",
               "dependsOn": [
                 "[resourceId('Microsoft.Web/sites', variables('functionName'))]",


### PR DESCRIPTION
## Summary

- Updated `apiVersion` for all `*/providers/diagnosticSettings` (Microsoft.Insights) resources from `2017-05-01-preview` to `2021-05-01-preview` in both AAD and Activity Logs ARM deployment templates
- Affected files: `deploy/aad/splunk-aad-logs-deploy-resources.json` and `deploy/activity/splunk-activity-logs-deploy-resources.json` (5 occurrences each, 10 total)
- No schema-breaking changes — the properties in use (`storageAccountId`, `metrics`, `logs`, `category`, `enabled`) are fully supported in the newer API version